### PR TITLE
Allow tasty 1.3 & 1.4

### DIFF
--- a/package/sparse-tensor.cabal
+++ b/package/sparse-tensor.cabal
@@ -64,7 +64,7 @@ test-suite test-sparse-tensor
   build-depends:       base              >= 4.9 && < 5,
                        hmatrix           >= 0.16.1 && < 0.21,
                        QuickCheck        >= 2.8.2 && < 2.14,
-                       tasty             >= 0.11 && < 1.3,
+                       tasty             >= 0.11 && < 1.5,
                        tasty-hunit       >= 0.9 && < 0.11,
                        tasty-quickcheck  >= 0.8 && < 0.11,
                        sparse-tensor


### PR DESCRIPTION
Related to commercialhaskell/stackage#5795; I haven't tested this locally, I just figured it would be easy to make the change and let CI yell at me if something broke.